### PR TITLE
Migrate tests to gz

### DIFF
--- a/ubuntu/debian/tests/build
+++ b/ubuntu/debian/tests/build
@@ -12,7 +12,7 @@ cd $WORKDIR
 cat <<EOF > igntest.c
 
 #include <iostream>
-#include <ignition/math.hh>
+#include <gz/math.hh>
 
 int main(int argc, char **argv)
 {
@@ -20,10 +20,10 @@ int main(int argc, char **argv)
   // 1: x = -1, y = 0
   // 2: x = 0, y = 1
   // 3: x = 1, y = 0
-  ignition::math::Triangled tri(
-      ignition::math::Vector2d(-1, 0),
-      ignition::math::Vector2d(0, 1),
-      ignition::math::Vector2d(1, 0));
+  gz::math::Triangled tri(
+      gz::math::Vector2d(-1, 0),
+      gz::math::Vector2d(0, 1),
+      gz::math::Vector2d(1, 0));
 
   // The individual vertices are accessible through the [] operator
   std::cout << "Vertex 1: " << tri[0] << "\n"
@@ -36,29 +36,29 @@ int main(int argc, char **argv)
             << "Side 3: " << tri.Side(2) << "\n";
 
   // It's also possible to set each vertex individually.
-  tri.Set(0, ignition::math::Vector2d(-10, 0));
-  tri.Set(1, ignition::math::Vector2d(0, 20));
-  tri.Set(2, ignition::math::Vector2d(10, 2));
+  tri.Set(0, gz::math::Vector2d(-10, 0));
+  tri.Set(1, gz::math::Vector2d(0, 20));
+  tri.Set(2, gz::math::Vector2d(10, 2));
 
   // Or set all the vertices at once.
-  tri.Set(ignition::math::Vector2d(-1, 0),
-          ignition::math::Vector2d(0, 1),
-          ignition::math::Vector2d(1, 0));
+  tri.Set(gz::math::Vector2d(-1, 0),
+          gz::math::Vector2d(0, 1),
+          gz::math::Vector2d(1, 0));
 
   // You can get the perimeter length and area of the triangle
   std::cout << "Perimeter=" << tri.Perimeter()
             << " Area=" << tri.Area() << "\n";
 
   // The Contains functions check if a line or point is inside the triangle
-  if (tri.Contains(ignition::math::Vector2d(0, 0.5)))
+  if (tri.Contains(gz::math::Vector2d(0, 0.5)))
     std::cout << "Triangle contains the point 0, 0.5\n";
   else
     std::cout << "Triangle does not contain the point 0, 0.5\n";
 
   // The Intersect function check if a line segment intersects the triangle.
   // It also returns the points of intersection
-  ignition::math::Vector2d pt1, pt2;
-  if (tri.Intersects(ignition::math::Line2d(-2, 0.5, 2, 0.5), pt1, pt2))
+  gz::math::Vector2d pt1, pt2;
+  if (tri.Intersects(gz::math::Line2d(-2, 0.5, 2, 0.5), pt1, pt2))
   {
     std::cout << "A line from (-2, 0.5) to (2, 0.5) intersects "
               << "the triangle at the\nfollowing points:\n"
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
   }
 
   // There are more functions in Triangle. Take a look at the API;
-  // http://ignitionrobotics.org/libraries/ign_mat/api
+  // http://gazebosim.org/libs/math
 }
 EOF
 


### PR DESCRIPTION
Otherwise debbuild fails with

```
/usr/lib/x86_64-linux-gnu/pkgconfig/../../..//include/ignition/math7/ignition/math/config.hh:41:72: note: #pragma message: ignition namespace is deprecated! Use gz instead!
   41 |     #pragma message("ignition namespace is deprecated! Use gz instead!")
      |                                                                        ^
```

https://build.osrfoundation.org/job/ign-math7-debbuilder/626/console